### PR TITLE
Created fns for creating predefined comms.

### DIFF
--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -38,7 +38,6 @@ pub type MPI_T_enum = *mut Struct_mca_base_var_enum_t;
 pub type MPI_T_pvar_handle = *mut Struct_mca_base_pvar_handle_t;
 pub type MPI_T_pvar_session = *mut Struct_mca_base_pvar_session_t;
 pub type MPI_Win = *mut Struct_ompi_win_t;
-pub type ompi_mpi_comm_world = Struct_ompi_communicator_t;
 
 pub const IMPI_CLIENT_COLOR: c_uint = 13;
 pub const IMPI_CLIENT_SIZE: c_uint = 12;
@@ -216,7 +215,10 @@ extern "C" {
     /* I know these are supposed to be the predefined types but,
      * using those types requires uncomfortable typecasts in rust.
      * The predefined types just have padding with the normal type.
+     * TODO: confirm this.
      */
+    pub static mut ompi_communicator_t: Struct_ompi_communicator_t;
+    pub static mut ompi_mpi_comm_world: Struct_ompi_communicator_t;
     pub static mut ompi_mpi_comm_self: Struct_ompi_communicator_t;
     pub static mut ompi_mpi_comm_null: Struct_ompi_communicator_t;
     pub static mut ompi_mpi_group_empty: Struct_ompi_group_t;

--- a/src/comm/mod.rs
+++ b/src/comm/mod.rs
@@ -1,0 +1,19 @@
+use bindings::{ompi_communicator_t, ompi_mpi_comm_world, ompi_mpi_comm_self};
+use bindings::{ompi_mpi_comm_null, MPI_Comm};
+
+pub fn new() -> MPI_Comm {
+  unsafe { &mut ompi_communicator_t }
+}
+
+pub fn world() -> MPI_Comm {
+  unsafe { &mut ompi_mpi_comm_world }
+}
+
+// self and Self reserved by rust, comm::comm_self seems redundant.
+pub fn slf() -> MPI_Comm {
+  unsafe { &mut ompi_mpi_comm_self }
+}
+
+pub fn null() -> MPI_Comm {
+  unsafe { &mut ompi_mpi_comm_null }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+// TODO: figure out how to repesent error conditions.
 extern crate libc;
 
 use std::env::Args;
@@ -7,17 +8,30 @@ use libc::{c_longlong, c_void, c_uint, c_double};
 pub mod bindings;
 use bindings::*;
 
-// Aliases for MPI_* types
-pub type CommWorld = ompi_mpi_comm_world;
+pub fn comm_new() -> MPI_Comm {
+  unsafe { &mut ompi_communicator_t }
+}
 
-// TODO: figure out how to repesent error conditions.
+pub fn comm_world() -> MPI_Comm {
+  unsafe { &mut ompi_mpi_comm_world }
+}
+
+pub fn comm_self() -> MPI_Comm {
+  unsafe { &mut ompi_mpi_comm_self }
+}
+
+pub fn comm_null() -> MPI_Comm {
+  unsafe { &mut ompi_mpi_comm_null }
+}
+
 /*
 pub fn init(argc: usize, argv: Vec<Args>) -> () {
   unsafe { ffi::MPI_Init(&argc as *mut c_int, argv) } //TODO: howdoi?
 }
 */
 
-/// Calls MPI_Init with null parameters, temporary function
+/// Calls MPI_Init with null parameters.
+/// As of MPI-2, MPI_Init will accept NULL as input parameters.
 pub fn init_null() -> i32 {
   let argc = 0 as *mut c_int;
   let argv = 0 as *mut *mut *mut c_char;
@@ -28,6 +42,8 @@ pub fn finalize() -> i32 {
   unsafe { MPI_Finalize() }
 }
 
+/// Returns the rank of the process in the communicator.
+/// Doesnt "return" rank as a pointer link in C.
 // TODO: Handle errors, dont just throw the error away
 pub fn comm_rank(comm: MPI_Comm) -> i32 {
   let mut rank = -1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,23 +6,9 @@ use libc::{ptrdiff_t, size_t, c_int, c_char};
 use libc::{c_longlong, c_void, c_uint, c_double};
 
 pub mod bindings;
+pub mod comm;
+
 use bindings::*;
-
-pub fn comm_new() -> MPI_Comm {
-  unsafe { &mut ompi_communicator_t }
-}
-
-pub fn comm_world() -> MPI_Comm {
-  unsafe { &mut ompi_mpi_comm_world }
-}
-
-pub fn comm_self() -> MPI_Comm {
-  unsafe { &mut ompi_mpi_comm_self }
-}
-
-pub fn comm_null() -> MPI_Comm {
-  unsafe { &mut ompi_mpi_comm_null }
-}
 
 /*
 pub fn init(argc: usize, argv: Vec<Args>) -> () {


### PR DESCRIPTION
ex. MPI_COMM_WORLD can be used by calling comm_world().
It is a function and not an object because of the type of
an MPI_Comm object as *mut Struct_ompi_communicator_t.
