### PR TITLE
Started creating tests.

### DIFF
--- a/tests/finalize.rs
+++ b/tests/finalize.rs
@@ -1,0 +1,13 @@
+extern crate mpi;
+
+use mpi::*;
+
+/* Since we are testing init and finalize, can't do any other tests that
+ * require a non-finalized proccess.
+ */
+#[test]
+fn init_null_finalize() {
+  let err = init_null();
+  assert_eq!(err, mpi::error::MPI_SUCCESS);
+  finalize();
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,0 +1,59 @@
+extern crate mpi;
+
+pub use mpi::*;
+
+// Need to wrap call to init_null to prevent each thread from calling init.
+fn sync_init() {
+  use std::sync::{Once, ONCE_INIT};
+  static INIT: Once = ONCE_INIT;
+  INIT.call_once(|| {
+    init_null();
+  });
+}
+
+/* Finalize can only be called once/process including threads.
+ * Can't test finalize due to race conditions, it would have to be called after
+ * all tests complete.
+ */
+#[test]
+fn init() {
+  sync_init();
+}
+
+#[cfg(test)]
+mod comm_tests {
+  use super::*;
+
+  #[test]
+  fn rank_in_world() {
+    super::sync_init();
+    let rank = comm::rank(comm::world());
+    match rank {
+      Ok(r) => assert_eq!(r, 0),
+      Err(e) => panic!("got error: {}", e.string)
+    }
+  }
+
+  #[test]
+  fn rank_in_self() {
+    super::sync_init();
+    let rank = comm::rank(comm::slf());
+    match rank {
+      Ok(r) => assert_eq!(r, 0),
+      Err(e) => panic!("got error: {}", e.string)
+    }
+  }
+
+  #[test]
+  fn rank_in_bad_comm() {
+    super::sync_init();
+    let comm = comm::new();
+    let rank = comm::rank(comm);
+    match rank {
+      Ok(r) => assert_eq!(r, 0),
+      Err(e) => panic!("got error: {}", e.string)
+    }
+  }
+
+
+}

--- a/tests/null_comm.rs
+++ b/tests/null_comm.rs
@@ -1,0 +1,12 @@
+extern crate mpi;
+
+use mpi::*;
+
+// The way ompi fails will kill the current process, other tests cannot go in here.
+#[test]
+#[should_panic]
+fn comm_null_rank() {
+  init_null();
+  let _ = comm::rank(comm::null());
+  finalize();
+}


### PR DESCRIPTION
comm::new() seems to have a type that does not exist in libmpi.
Each test function in a test file spawns a thread, causes race
conditions with init and finalize.
For now I will synchonize access to init_null, and not call finalize.
